### PR TITLE
增加UAPI宏控制导出其它函数调用约定如__stdcall

### DIFF
--- a/lua_tinker/lua_tinker.h
+++ b/lua_tinker/lua_tinker.h
@@ -16,6 +16,9 @@
 #include <stdio.h>
 #include <typeinfo>
 
+#ifndef UAPI
+#define UAPI __stdcall
+#endif
 
 namespace lua_tinker
 {
@@ -371,36 +374,42 @@ namespace lua_tinker
    struct functor
    {
       static int invoke ( lua_State *L ) { push ( L, upvalue_<RVal ( *)( T1, T2, T3, T4, T5 )> ( L )( read<T1> ( L, 1 ), read<T2> ( L, 2 ), read<T3> ( L, 3 ), read<T4> ( L, 4 ), read<T5> ( L, 5 ) ) ); return 1; }
+	  static int invokeU ( lua_State *L ) { push ( L, upvalue_<RVal (UAPI *)( T1, T2, T3, T4, T5 )> ( L )( read<T1> ( L, 1 ), read<T2> ( L, 2 ), read<T3> ( L, 3 ), read<T4> ( L, 4 ), read<T5> ( L, 5 ) ) ); return 1; }
    };
 
    template<typename RVal, typename T1, typename T2, typename T3, typename T4>
    struct functor < RVal, T1, T2, T3, T4 >
    {
       static int invoke ( lua_State *L ) { push ( L, upvalue_<RVal ( *)( T1, T2, T3, T4 )> ( L )( read<T1> ( L, 1 ), read<T2> ( L, 2 ), read<T3> ( L, 3 ), read<T4> ( L, 4 ) ) ); return 1; }
+	  static int invokeU ( lua_State *L ) { push ( L, upvalue_<RVal (UAPI *)( T1, T2, T3, T4 )> ( L )( read<T1> ( L, 1 ), read<T2> ( L, 2 ), read<T3> ( L, 3 ), read<T4> ( L, 4 ) ) ); return 1; }
    };
 
    template<typename RVal, typename T1, typename T2, typename T3>
    struct functor < RVal, T1, T2, T3 >
    {
       static int invoke ( lua_State *L ) { push ( L, upvalue_<RVal ( *)( T1, T2, T3 )> ( L )( read<T1> ( L, 1 ), read<T2> ( L, 2 ), read<T3> ( L, 3 ) ) ); return 1; }
+	  static int invokeU ( lua_State *L ) { push ( L, upvalue_<RVal (UAPI *)( T1, T2, T3 )> ( L )( read<T1> ( L, 1 ), read<T2> ( L, 2 ), read<T3> ( L, 3 ) ) ); return 1; }
    };
 
    template<typename RVal, typename T1, typename T2>
    struct functor < RVal, T1, T2 >
    {
       static int invoke ( lua_State *L ) { push ( L, upvalue_<RVal ( *)( T1, T2 )> ( L )( read<T1> ( L, 1 ), read<T2> ( L, 2 ) ) ); return 1; }
+	  static int invokeU ( lua_State *L ) { push ( L, upvalue_<RVal (UAPI *)( T1, T2 )> ( L )( read<T1> ( L, 1 ), read<T2> ( L, 2 ) ) ); return 1; }
    };
 
    template<typename RVal, typename T1>
    struct functor < RVal, T1 >
    {
       static int invoke ( lua_State *L ) { push ( L, upvalue_<RVal ( *)( T1 )> ( L )( read<T1> ( L, 1 ) ) ); return 1; }
+	  static int invokeU ( lua_State *L ) { push ( L, upvalue_<RVal (UAPI *)( T1 )> ( L )( read<T1> ( L, 1 ) ) ); return 1; }
    };
 
    template<typename RVal>
    struct functor < RVal >
    {
       static int invoke ( lua_State *L ) { push ( L, upvalue_<RVal ( *)( )> ( L )( ) ); return 1; }
+	  static int invokeU ( lua_State *L ) { push ( L, upvalue_<RVal (UAPI *)( )> ( L )( ) ); return 1; }
    };
 
    // functor (without return value)
@@ -411,36 +420,42 @@ namespace lua_tinker
    struct functor < void, T1, T2, T3, T4, T5 >
    {
       static int invoke ( lua_State *L ) { upvalue_<void ( *)( T1, T2, T3, T4, T5 )> ( L )( read<T1> ( L, 1 ), read<T2> ( L, 2 ), read<T3> ( L, 3 ), read<T4> ( L, 4 ), read<T5> ( L, 5 ) ); return 0; }
+	  static int invokeU ( lua_State *L ) { upvalue_<void (UAPI *)( T1, T2, T3, T4, T5 )> ( L )( read<T1> ( L, 1 ), read<T2> ( L, 2 ), read<T3> ( L, 3 ), read<T4> ( L, 4 ), read<T5> ( L, 5 ) ); return 0; }
    };
 
    template<typename T1, typename T2, typename T3, typename T4>
    struct functor < void, T1, T2, T3, T4 >
    {
       static int invoke ( lua_State *L ) { upvalue_<void ( *)( T1, T2, T3, T4 )> ( L )( read<T1> ( L, 1 ), read<T2> ( L, 2 ), read<T3> ( L, 3 ), read<T4> ( L, 4 ) ); return 0; }
+	  static int invokeU ( lua_State *L ) { upvalue_<void (UAPI *)( T1, T2, T3, T4 )> ( L )( read<T1> ( L, 1 ), read<T2> ( L, 2 ), read<T3> ( L, 3 ), read<T4> ( L, 4 ) ); return 0; }
    };
 
    template<typename T1, typename T2, typename T3>
    struct functor < void, T1, T2, T3 >
    {
       static int invoke ( lua_State *L ) { upvalue_<void ( *)( T1, T2, T3 )> ( L )( read<T1> ( L, 1 ), read<T2> ( L, 2 ), read<T3> ( L, 3 ) ); return 0; }
+	  static int invokeU ( lua_State *L ) { upvalue_<void (UAPI *)( T1, T2, T3 )> ( L )( read<T1> ( L, 1 ), read<T2> ( L, 2 ), read<T3> ( L, 3 ) ); return 0; }
    };
 
    template<typename T1, typename T2>
    struct functor < void, T1, T2 >
    {
       static int invoke ( lua_State *L ) { upvalue_<void ( *)( T1, T2 )> ( L )( read<T1> ( L, 1 ), read<T2> ( L, 2 ) ); return 0; }
+	  static int invokeU ( lua_State *L ) { upvalue_<void (UAPI *)( T1, T2 )> ( L )( read<T1> ( L, 1 ), read<T2> ( L, 2 ) ); return 0; }
    };
 
    template<typename T1>
    struct functor < void, T1 >
    {
       static int invoke ( lua_State *L ) { upvalue_<void ( *)( T1 )> ( L )( read<T1> ( L, 1 ) ); return 0; }
+	  static int invokeU ( lua_State *L ) { upvalue_<void (UAPI *)( T1 )> ( L )( read<T1> ( L, 1 ) ); return 0; }
    };
 
    template<>
    struct functor < void >
    {
       static int invoke ( lua_State *L ) { upvalue_<void ( *)( )> ( L )( ); return 0; }
+	  static int invokeU ( lua_State *L ) { upvalue_<void (UAPI *)( )> ( L )( ); return 0; }
    };
 
    // functor (non-managed)
@@ -448,12 +463,14 @@ namespace lua_tinker
    struct functor < int, lua_State*, T1 >
    {
       static int invoke ( lua_State *L ) { return upvalue_<int ( *)( lua_State*, T1 )> ( L )( L, read<T1> ( L, 1 ) ); }
+	  static int invokeU ( lua_State *L ) { return upvalue_<int (UAPI *)( lua_State*, T1 )> ( L )( L, read<T1> ( L, 1 ) ); }
    };
 
    template<>
    struct functor < int, lua_State* >
    {
       static int invoke ( lua_State *L ) { return upvalue_<int ( *)( lua_State* )> ( L )( L ); }
+	  static int invokeU ( lua_State *L ) { return upvalue_<int (UAPI *)( lua_State* )> ( L )( L ); }
    };
 
    // push_functor
@@ -501,6 +518,49 @@ namespace lua_tinker
       lua_pushcclosure ( L, functor<RVal, T1, T2, T3, T4, T5>::invoke, 1 );
    }
 
+#ifndef _WIN64
+   template<typename RVal>
+   void push_functor ( lua_State *L, RVal (UAPI *func )( ) )
+   {
+	   ( void ) func;
+	   lua_pushcclosure ( L, functor<RVal>::invokeU, 1 );
+   }
+
+   template<typename RVal, typename T1>
+   void push_functor ( lua_State *L, RVal (UAPI *func )( T1 ) )
+   {
+	   ( void ) func;
+	   lua_pushcclosure ( L, functor<RVal, T1>::invokeU, 1 );
+   }
+
+   template<typename RVal, typename T1, typename T2>
+   void push_functor ( lua_State *L, RVal (UAPI  *func )( T1, T2 ) )
+   {
+	   ( void ) func;
+	   lua_pushcclosure ( L, functor<RVal, T1, T2>::invokeU, 1 );
+   }
+
+   template<typename RVal, typename T1, typename T2, typename T3>
+   void push_functor ( lua_State *L, RVal (UAPI  *func )( T1, T2, T3 ) )
+   {
+	   ( void ) func;
+	   lua_pushcclosure ( L, functor<RVal, T1, T2, T3>::invokeU, 1 );
+   }
+
+   template<typename RVal, typename T1, typename T2, typename T3, typename T4>
+   void push_functor ( lua_State *L, RVal (UAPI  *func )( T1, T2, T3, T4 ) )
+   {
+	   ( void ) func;
+	   lua_pushcclosure ( L, functor<RVal, T1, T2, T3, T4>::invokeU, 1 );
+   }
+
+   template<typename RVal, typename T1, typename T2, typename T3, typename T4, typename T5>
+   void push_functor ( lua_State *L, RVal (UAPI  *func )( T1, T2, T3, T4, T5 ) )
+   {
+	   ( void ) func;
+	   lua_pushcclosure ( L, functor<RVal, T1, T2, T3, T4, T5>::invokeU, 1 );
+   }
+#endif//_WIN64
    // member variable
    struct var_base
    {
@@ -523,36 +583,42 @@ namespace lua_tinker
    struct mem_functor
    {
       static int invoke ( lua_State *L ) { push ( L, ( read<T*> ( L, 1 )->*upvalue_<RVal ( T::* )( T1, T2, T3, T4, T5 )> ( L ) )( read<T1> ( L, 2 ), read<T2> ( L, 3 ), read<T3> ( L, 4 ), read<T4> ( L, 5 ), read<T5> ( L, 6 ) ) );; return 1; }
+	  static int invokeU ( lua_State *L ) { push ( L, ( read<T*> ( L, 1 )->*upvalue_<RVal (UAPI T::* )( T1, T2, T3, T4, T5 )> ( L ) )( read<T1> ( L, 2 ), read<T2> ( L, 3 ), read<T3> ( L, 4 ), read<T4> ( L, 5 ), read<T5> ( L, 6 ) ) );; return 1; }
    };
 
    template<typename RVal, typename T, typename T1, typename T2, typename T3, typename T4>
    struct mem_functor < RVal, T, T1, T2, T3, T4 >
    {
       static int invoke ( lua_State *L ) { push ( L, ( read<T*> ( L, 1 )->*upvalue_<RVal ( T::* )( T1, T2, T3, T4 )> ( L ) )( read<T1> ( L, 2 ), read<T2> ( L, 3 ), read<T3> ( L, 4 ), read<T4> ( L, 5 ) ) ); return 1; }
+	  static int invokeU ( lua_State *L ) { push ( L, ( read<T*> ( L, 1 )->*upvalue_<RVal (UAPI T::* )( T1, T2, T3, T4 )> ( L ) )( read<T1> ( L, 2 ), read<T2> ( L, 3 ), read<T3> ( L, 4 ), read<T4> ( L, 5 ) ) ); return 1; }
    };
 
    template<typename RVal, typename T, typename T1, typename T2, typename T3>
    struct mem_functor < RVal, T, T1, T2, T3 >
    {
       static int invoke ( lua_State *L ) { push ( L, ( read<T*> ( L, 1 )->*upvalue_<RVal ( T::* )( T1, T2, T3 )> ( L ) )( read<T1> ( L, 2 ), read<T2> ( L, 3 ), read<T3> ( L, 4 ) ) ); return 1; }
+	  static int invokeU ( lua_State *L ) { push ( L, ( read<T*> ( L, 1 )->*upvalue_<RVal (UAPI T::* )( T1, T2, T3 )> ( L ) )( read<T1> ( L, 2 ), read<T2> ( L, 3 ), read<T3> ( L, 4 ) ) ); return 1; }
    };
 
    template<typename RVal, typename T, typename T1, typename T2>
    struct mem_functor < RVal, T, T1, T2 >
    {
       static int invoke ( lua_State *L ) { push ( L, ( read<T*> ( L, 1 )->*upvalue_<RVal ( T::* )( T1, T2 )> ( L ) )( read<T1> ( L, 2 ), read<T2> ( L, 3 ) ) ); return 1; }
+	  static int invokeU ( lua_State *L ) { push ( L, ( read<T*> ( L, 1 )->*upvalue_<RVal (UAPI T::* )( T1, T2 )> ( L ) )( read<T1> ( L, 2 ), read<T2> ( L, 3 ) ) ); return 1; }
    };
 
    template<typename RVal, typename T, typename T1>
    struct mem_functor < RVal, T, T1 >
    {
       static int invoke ( lua_State *L ) { push ( L, ( read<T*> ( L, 1 )->*upvalue_<RVal ( T::* )( T1 )> ( L ) )( read<T1> ( L, 2 ) ) ); return 1; }
+	  static int invokeU ( lua_State *L ) { push ( L, ( read<T*> ( L, 1 )->*upvalue_<RVal (UAPI T::* )( T1 )> ( L ) )( read<T1> ( L, 2 ) ) ); return 1; }
    };
 
    template<typename RVal, typename T>
    struct mem_functor < RVal, T >
    {
       static int invoke ( lua_State *L ) { push ( L, ( read<T*> ( L, 1 )->*upvalue_<RVal ( T::* )( )> ( L ) )( ) ); return 1; }
+	  static int invokeU ( lua_State *L ) { push ( L, ( read<T*> ( L, 1 )->*upvalue_<RVal (UAPI T::* )( )> ( L ) )( ) ); return 1; }
    };
 
    // class member functor (without return value)
@@ -560,36 +626,42 @@ namespace lua_tinker
    struct mem_functor < void, T, T1, T2, T3, T4, T5 >
    {
       static int invoke ( lua_State *L )  { ( read<T*> ( L, 1 )->*upvalue_<void( T::* )( T1, T2, T3, T4, T5 )> ( L ) )( read<T1> ( L, 2 ), read<T2> ( L, 3 ), read<T3> ( L, 4 ), read<T4> ( L, 5 ), read<T5> ( L, 6 ) ); return 0; }
+	  static int invokeU ( lua_State *L )  { ( read<T*> ( L, 1 )->*upvalue_<void(UAPI T::* )( T1, T2, T3, T4, T5 )> ( L ) )( read<T1> ( L, 2 ), read<T2> ( L, 3 ), read<T3> ( L, 4 ), read<T4> ( L, 5 ), read<T5> ( L, 6 ) ); return 0; }
    };
 
    template<typename T, typename T1, typename T2, typename T3, typename T4>
    struct mem_functor < void, T, T1, T2, T3, T4 >
    {
       static int invoke ( lua_State *L )  { ( read<T*> ( L, 1 )->*upvalue_<void( T::* )( T1, T2, T3, T4 )> ( L ) )( read<T1> ( L, 2 ), read<T2> ( L, 3 ), read<T3> ( L, 4 ), read<T4> ( L, 5 ) ); return 0; }
+	  static int invokeU ( lua_State *L )  { ( read<T*> ( L, 1 )->*upvalue_<void(UAPI T::* )( T1, T2, T3, T4 )> ( L ) )( read<T1> ( L, 2 ), read<T2> ( L, 3 ), read<T3> ( L, 4 ), read<T4> ( L, 5 ) ); return 0; }
    };
 
    template<typename T, typename T1, typename T2, typename T3>
    struct mem_functor < void, T, T1, T2, T3 >
    {
       static int invoke ( lua_State *L )  { ( read<T*> ( L, 1 )->*upvalue_<void( T::* )( T1, T2, T3 )> ( L ) )( read<T1> ( L, 2 ), read<T2> ( L, 3 ), read<T3> ( L, 4 ) ); return 0; }
+	  static int invokeU ( lua_State *L )  { ( read<T*> ( L, 1 )->*upvalue_<void(UAPI T::* )( T1, T2, T3 )> ( L ) )( read<T1> ( L, 2 ), read<T2> ( L, 3 ), read<T3> ( L, 4 ) ); return 0; }
    };
 
    template<typename T, typename T1, typename T2>
    struct mem_functor < void, T, T1, T2 >
    {
       static int invoke ( lua_State *L )  { ( read<T*> ( L, 1 )->*upvalue_<void( T::* )( T1, T2 )> ( L ) )( read<T1> ( L, 2 ), read<T2> ( L, 3 ) ); return 0; }
+	  static int invokeU ( lua_State *L )  { ( read<T*> ( L, 1 )->*upvalue_<void(UAPI T::* )( T1, T2 )> ( L ) )( read<T1> ( L, 2 ), read<T2> ( L, 3 ) ); return 0; }
    };
 
    template<typename T, typename T1>
    struct mem_functor < void, T, T1 >
    {
       static int invoke ( lua_State *L )  { ( read<T*> ( L, 1 )->*upvalue_<void( T::* )( T1 )> ( L ) )( read<T1> ( L, 2 ) ); return 0; }
+	  static int invokeU ( lua_State *L )  { ( read<T*> ( L, 1 )->*upvalue_<void(UAPI T::* )( T1 )> ( L ) )( read<T1> ( L, 2 ) ); return 0; }
    };
 
    template<typename T>
    struct mem_functor < void, T >
    {
       static int invoke ( lua_State *L )  { ( read<T*> ( L, 1 )->*upvalue_<void( T::* )( )> ( L ) )( ); return 0; }
+	  static int invokeU ( lua_State *L )  { ( read<T*> ( L, 1 )->*upvalue_<void(UAPI T::* )( )> ( L ) )( ); return 0; }
    };
 
    // class member functor (non-managed)
@@ -597,12 +669,14 @@ namespace lua_tinker
    struct mem_functor < int, T, lua_State*, T1 >
    {
       static int invoke ( lua_State *L ) { return ( read<T*> ( L, 1 )->*upvalue_<int( T::* )( lua_State*, T1 )> ( L ) )( L, read<T1> ( L, 2 ) ); }
+	  static int invokeU ( lua_State *L ) { return ( read<T*> ( L, 1 )->*upvalue_<int(UAPI T::* )( lua_State*, T1 )> ( L ) )( L, read<T1> ( L, 2 ) ); }
    };
 
    template<typename T>
    struct mem_functor < int, T, lua_State* >
    {
       static int invoke ( lua_State *L ) { return ( read<T*> ( L, 1 )->*upvalue_<int( T::* )( lua_State* )> ( L ) )( L ); }
+	  static int invokeU ( lua_State *L ) { return ( read<T*> ( L, 1 )->*upvalue_<int(UAPI T::* )( lua_State* )> ( L ) )( L ); }
    };
 
    // push_functor
@@ -690,6 +764,92 @@ namespace lua_tinker
       lua_pushcclosure ( L, mem_functor<RVal, T, T1, T2, T3, T4, T5>::invoke, 1 );
    }
 
+#ifndef _WIN64
+   // push_functor
+   template<typename RVal, typename T>
+   void push_functor ( lua_State *L, RVal (UAPI T::*func )( ) )
+   {
+	   ( void ) func;
+	   lua_pushcclosure ( L, mem_functor<RVal, T>::invokeU, 1 );
+   }
+
+   template<typename RVal, typename T>
+   void push_functor ( lua_State *L, RVal (UAPI T::*func )( ) const )
+   {
+	   ( void ) func;
+	   lua_pushcclosure ( L, mem_functor<RVal, T>::invokeU, 1 );
+   }
+
+   template<typename RVal, typename T, typename T1>
+   void push_functor ( lua_State *L, RVal (UAPI T::*func )( T1 ) )
+   {
+	   ( void ) func;
+	   lua_pushcclosure ( L, mem_functor<RVal, T, T1>::invokeU, 1 );
+   }
+
+   template<typename RVal, typename T, typename T1>
+   void push_functor ( lua_State *L, RVal (UAPI T::*func )( T1 ) const )
+   {
+	   ( void ) func;
+	   lua_pushcclosure ( L, mem_functor<RVal, T, T1>::invokeU, 1 );
+   }
+
+   template<typename RVal, typename T, typename T1, typename T2>
+   void push_functor ( lua_State *L, RVal (UAPI T::*func )( T1, T2 ) )
+   {
+	   ( void ) func;
+	   lua_pushcclosure ( L, mem_functor<RVal, T, T1, T2>::invokeU, 1 );
+   }
+
+   template<typename RVal, typename T, typename T1, typename T2>
+   void push_functor ( lua_State *L, RVal (UAPI T::*func )( T1, T2 ) const )
+   {
+	   ( void ) func;
+	   lua_pushcclosure ( L, mem_functor<RVal, T, T1, T2>::invokeU, 1 );
+   }
+
+   template<typename RVal, typename T, typename T1, typename T2, typename T3>
+   void push_functor ( lua_State *L, RVal (UAPI T::*func )( T1, T2, T3 ) )
+   {
+	   ( void ) func;
+	   lua_pushcclosure ( L, mem_functor<RVal, T, T1, T2, T3>::invokeU, 1 );
+   }
+
+   template<typename RVal, typename T, typename T1, typename T2, typename T3>
+   void push_functor ( lua_State *L, RVal (UAPI T::*func )( T1, T2, T3 ) const )
+   {
+	   ( void ) func;
+	   lua_pushcclosure ( L, mem_functor<RVal, T, T1, T2, T3>::invokeU, 1 );
+   }
+
+   template<typename RVal, typename T, typename T1, typename T2, typename T3, typename T4>
+   void push_functor ( lua_State *L, RVal (UAPI T::*func )( T1, T2, T3, T4 ) )
+   {
+	   ( void ) func;
+	   lua_pushcclosure ( L, mem_functor<RVal, T, T1, T2, T3, T4>::invokeU, 1 );
+   }
+
+   template<typename RVal, typename T, typename T1, typename T2, typename T3, typename T4>
+   void push_functor ( lua_State *L, RVal (UAPI T::*func )( T1, T2, T3, T4 ) const )
+   {
+	   ( void ) func;
+	   lua_pushcclosure ( L, mem_functor<RVal, T, T1, T2, T3, T4>::invokeU, 1 );
+   }
+
+   template<typename RVal, typename T, typename T1, typename T2, typename T3, typename T4, typename T5>
+   void push_functor ( lua_State *L, RVal (UAPI T::*func )( T1, T2, T3, T4, T5 ) )
+   {
+	   ( void ) func;
+	   lua_pushcclosure ( L, mem_functor<RVal, T, T1, T2, T3, T4, T5>::invokeU, 1 );
+   }
+
+   template<typename RVal, typename T, typename T1, typename T2, typename T3, typename T4, typename T5>
+   void push_functor ( lua_State *L, RVal (UAPI T::*func )( T1, T2, T3, T4, T5 ) const )
+   {
+	   ( void ) func;
+	   lua_pushcclosure ( L, mem_functor<RVal, T, T1, T2, T3, T4, T5>::invokeU, 1 );
+   }
+#endif//_WIN64
    // constructor
    template<typename T, typename T1, typename T2, typename T3, typename T4, typename T5>
    int constructor ( lua_State *L )
@@ -801,21 +961,6 @@ namespace lua_tinker
    }
 
 
-
-
-   template <typename T>
-   int pcall_push ( lua_State*L, T value )
-   {
-      push ( L, value );
-      return 1;
-   }
-   template <typename TFirst, typename... TArgs>
-   int pcall_push ( lua_State *L, TFirst first, TArgs ... args )
-   {
-      push ( L, first );
-      return 1 + pcall_push ( L, args... );
-   }
-
    template<typename RVal>
    RVal call ( lua_State* L, const char* name )
    {
@@ -835,34 +980,78 @@ namespace lua_tinker
       lua_remove ( L, errfunc );
       return pop<RVal> ( L );
    }
-   template <typename RVal, typename... TArgs>
-   RVal call ( lua_State *L, const char * name, TArgs ... args )
+
+   template<typename RVal, typename T1>
+   RVal call(lua_State* L, const char* name, T1 arg)
    {
-      lua_pushcclosure ( L, on_error, 0 );
-      int errfunc = lua_gettop ( L );
+	   lua_pushcclosure(L, on_error, 0);
+	   int errfunc = lua_gettop(L);
+	   lua_getglobal(L, name);
+	   if(lua_isfunction(L,-1))
+	   {
+		   push(L, arg);
+		   if(lua_pcall(L, 1, 1, errfunc) != 0)
+		   {
+			   lua_pop(L, 1);
+		   }
+	   }
+	   else
+	   {
+		   print_error(L, "lua_tinker::call() attempt to call global `%s' (not a function)", name);
+	   }
 
-      lua_getglobal ( L, name );
-      if ( lua_isfunction ( L, -1 ) )
-      {
-         int count = sizeof ...(args);
-         if ( count > 0 )
-         {
-
-            pcall_push ( L, args... );
-         }
-         lua_pcall ( L, count, 1, errfunc );
-      }
-      else
-      {
-         print_error ( L, "lua_tinker::call() attempt to call global `%s' (not a function)", name );
-      }
-
-      lua_remove ( L, errfunc );
-      return pop<RVal> ( L );
-
+	   lua_remove(L, -2);
+	   return pop<RVal>(L);
    }
 
+   template<typename RVal, typename T1, typename T2>
+   RVal call(lua_State* L, const char* name, T1 arg1, T2 arg2)
+   {
+	   lua_pushcclosure(L, on_error, 0);
+	   int errfunc = lua_gettop(L);
+	   lua_getglobal(L, name);
+	   if(lua_isfunction(L,-1))
+	   {
+		   push(L, arg1);
+		   push(L, arg2);
+		   if(lua_pcall(L, 2, 1, errfunc) != 0)
+		   {
+			   lua_pop(L, 1);
+		   }
+	   }
+	   else
+	   {
+		   print_error(L, "lua_tinker::call() attempt to call global `%s' (not a function)", name);
+	   }
 
+	   lua_remove(L, -2);
+	   return pop<RVal>(L);
+   }
+
+   template<typename RVal, typename T1, typename T2, typename T3>
+   RVal call(lua_State* L, const char* name, T1 arg1, T2 arg2, T3 arg3)
+   {
+	   lua_pushcclosure(L, on_error, 0);
+	   int errfunc = lua_gettop(L);
+	   lua_getglobal(L, name);
+	   if(lua_isfunction(L,-1))
+	   {
+		   push(L, arg1);
+		   push(L, arg2);
+		   push(L, arg3);
+		   if(lua_pcall(L, 3, 1, errfunc) != 0)
+		   {
+			   lua_pop(L, 1);
+		   }
+	   }
+	   else
+	   {
+		   print_error(L, "lua_tinker::call() attempt to call global `%s' (not a function)", name);
+	   }
+
+	   lua_remove(L, -2);
+	   return pop<RVal>(L);
+   }
 
 
    // class helper


### PR DESCRIPTION
I had upgraded lua_tinker to support exporting functions modified by other call protocol such as __stdcall. In my test, it worked well.